### PR TITLE
Adding support for Visual Studio Live Share

### DIFF
--- a/src/CheckpointsController.ts
+++ b/src/CheckpointsController.ts
@@ -115,7 +115,7 @@ export class CheckpointsController {
 	*/
 	private async onAddCheckpoint() {
 
-		if (this.activeEditor.document.isUntitled) {
+		if (this.activeEditor.document.uri.scheme === "untitled") {
 			console.log(`Failed to add file to store. Unsaved documents are currently not supported`);
 			window.showInformationMessage("Untitled documents are currently not supported");
 			return;
@@ -203,7 +203,7 @@ export class CheckpointsController {
 				if (textDocument.isUntitled) {
 					window.showInformationMessage(`Restored checkpoint '${checkpointNode.label}'`);		
 				} else {
-					window.showInformationMessage(`Restored '${textDocument.fileName}' to checkpoint '${checkpointNode.label}'`);
+					window.showInformationMessage(`Restored '${checkpointNode.id}' to checkpoint '${checkpointNode.label}'`);
 					textDocument.save();
 				}
 			}
@@ -214,7 +214,7 @@ export class CheckpointsController {
 		}
 
 		// The file is not open in the currently active editor, open it.
-		if (success && checkpointNode.parentId !== this.model.checkpointContext.fsPath) {
+		if (success && checkpointNode.parentId !== this.model.checkpointContext.toString()) {
 			let editor = await window.showTextDocument(textDocument, {
 				preserveFocus: false,
 				preview: true,
@@ -229,7 +229,7 @@ export class CheckpointsController {
 	private onOpenFile(checkpointNode: CheckpointNode) {
 		console.log(`Opening file: '${checkpointNode.nodeId}'`);
 
-		workspace.openTextDocument(checkpointNode.nodeId).then(
+		workspace.openTextDocument(Uri.parse(checkpointNode.nodeId)).then(
 			// On success:
 			textDocument => {
 				window.showTextDocument(textDocument, {
@@ -287,7 +287,7 @@ export class CheckpointsController {
 	 */
 	private async onDiffWithCurrent(checkpointNode: CheckpointNode) {
 		try {
-			let textDocument = await workspace.openTextDocument(checkpointNode.parentId);
+			let textDocument = await workspace.openTextDocument(Uri.parse(checkpointNode.parentId));
 			this.documentView.showDiffWithDocument(textDocument.uri, checkpointNode.nodeId);
 		} catch (err) {
 			console.error(err);
@@ -337,7 +337,7 @@ export class CheckpointsController {
 	 */
 	private async openTextDocument(checkpoint: CheckpointNode) {
 		try{
-			return await workspace.openTextDocument(checkpoint.parentId);
+			return await workspace.openTextDocument(Uri.parse(checkpoint.parentId));
 		} catch (err) {
 			window.showWarningMessage("Failed to open original document, opening untitled document instead.")
 			return await workspace.openTextDocument({

--- a/src/CheckpointsDocumentView.ts
+++ b/src/CheckpointsDocumentView.ts
@@ -47,7 +47,7 @@ export class CheckpointsDocumentView implements TextDocumentContentProvider {
 			return;
 		}
 		const checkpointUri = this.getCheckpointUri(checkpoint);
-		const comparingDocumentName = path.basename(checkpointUri.fsPath);
+		const comparingDocumentName = path.basename(checkpointUri.toString());
 		const diffTitle = `${comparingDocumentName}<->${checkpoint.name}`;
 		commands.executeCommand('vscode.diff', comparisonDocumentUri, checkpointUri, diffTitle);
 	}
@@ -115,7 +115,7 @@ export class CheckpointsDocumentView implements TextDocumentContentProvider {
 	 * @param checkpoint The checkpoint
 	 */
 	private getCheckpointUri(checkpoint: ICheckpoint): Uri {
-		const filePath = Uri.file(checkpoint.parent);
+		const filePath = Uri.parse(checkpoint.parent);
 
 		// Set the checkpoint id to be the 'fragment' of the uri.
 		// The uri's 'path' part needs to be a file (fake or not) that has the

--- a/src/CheckpointsModel.ts
+++ b/src/CheckpointsModel.ts
@@ -142,7 +142,7 @@ export class CheckpointsModel {
 		// then return. We do not want to update the tree view in 
 		// these cases because we loose selection marker unnecessarily.
 		if (this.currentCheckpointContext && 
-			(this.currentCheckpointContext.fsPath === fileUri.fsPath ||
+			(this.currentCheckpointContext.toString() === fileUri.toString() ||
 			fileUri.scheme === 'checkpointsDocumentView')) {
 			return;
 		}
@@ -171,19 +171,14 @@ export class CheckpointsModel {
 	 * @param document The document to save
 	 */
 	add(document: TextDocument, name: string, timestamp: number): void {
-		console.log(`Adding file '${document.fileName}' to checkpoint store.`);
+		const documentId = document.uri.toString();
+		console.log(`Adding file '${documentId}' to checkpoint store.`);
 		
+
 		// If there is no entry for this document, then create one
-		if (!this.checkpointStore.files.byId[document.fileName]) {
-
-			// Set file name and extra name (truncated relative path)
-
-			// First create an uri object of the file path
-			let fileUri = Uri.file(document.fileName);
-			// Get the relative path from workspace root to the file. 
-			let relativeFilePath = workspace.asRelativePath(fileUri);
+		if (!this.checkpointStore.files.byId[documentId]) {
 			// Remove the active file name and use as extra name.
-			let extraName = path.dirname(relativeFilePath);
+			let extraName = path.dirname(documentId);
 			// Truncate the name if it is too long
 			if (extraName.length > this.maxLengthFileName) {
 				extraName = '...' + extraName.substr(
@@ -192,11 +187,11 @@ export class CheckpointsModel {
 				);
 			}
 
-			let baseName = path.basename(document.fileName);
+			let baseName = path.basename(documentId);
 
 			// create the file
 			let file: IFile = {
-				id: document.fileName,
+				id: documentId,
 				name: baseName,
 				extraName: extraName,
 				fileNameDuplicates: [],
@@ -211,7 +206,7 @@ export class CheckpointsModel {
 
 		// create the checkpoint
 		let checkpoint: ICheckpoint = {
-			parent: document.fileName,
+			parent: documentId,
 			timestamp: timestamp,
 			text: document.getText(),
 			name: name,

--- a/src/CheckpointsTreeView.ts
+++ b/src/CheckpointsTreeView.ts
@@ -63,12 +63,12 @@ export class CheckpointsTreeView implements TreeDataProvider<CheckpointNode> {
 			// Control the collapsed state of the file. We want it to expand when the file is selected
 			// and collapse when it is not selected.
 			element.collapsibleState =
-				this.model.checkpointContext.fsPath === file.id
+				this.model.checkpointContext.toString() === file.id
 					? TreeItemCollapsibleState.Expanded
 					: TreeItemCollapsibleState.Collapsed;
 
 			// Set the file icon
-			if (this.model.checkpointContext.fsPath === file.id) {
+			if (this.model.checkpointContext.toString() === file.id) {
 				element.iconPath = {
 					light: this.context.asAbsolutePath('resources/light/file-selected.svg'),
 					dark: this.context.asAbsolutePath('resources/dark/file-selected.svg'),
@@ -149,7 +149,7 @@ export class CheckpointsTreeView implements TreeDataProvider<CheckpointNode> {
 		// that belong to the currently active file only, return checkpoint
 		// nodes.
 		if (!element && showActiveFileOnly) {
-			let checkpoints = this.model.getCheckpoints(this.model.checkpointContext.fsPath);
+			let checkpoints = this.model.getCheckpoints(this.model.checkpointContext.toString());
 			return checkpoints.map(checkpoint => {
 				return new CheckpointNode(checkpoint.id, checkpoint.parent);
 			});


### PR DESCRIPTION
This PR adds support for [Visual Studio Live Share](http://aka.ms/vsls), by ensuring that all serialization and parsing of document URIs are done using the VS Code APIs which preserve the correct scheme. This is important because "guests" within a Live Share session see remote files using the `vsls:` scheme, whereas the the host, as well as non-Live Share users, would see files using the `file:` scheme. Therefore, this change preserves the existing behavior, while allowing Checkpoint users to continue using it within the context of a collaboration session 🚀 

What's cool about this, is that users can create independent checkpoints, which track not only there own changes, but also those coming from other participants in a Live Share session (which enables real-time co-editing). This enhances the pair programming experience, and allow devs to create checkpoints, without needing to rely on Git commits to do it.

In detail, this PR makes three key refactorings:

1. Use `Uri.toString()` as opposed to `Uri.fsPath` or `TextDocument.fileName`, since the later two APIs strip the `Uri`'s scheme, which removes the `vsls:` portion that is critical for Live Share.

2. Use `Uri.parse()` as opposed to `Uri.file()`, since the later always appends the `file://` scheme to the parse `Uri`, as opposed to parsing the provided string, and respecting its scheme (if there is one)

3. Using the overload of `workspace.openTextDocument` that provides a `Uri` instance instead of a string, since when providing a string, it internally calls `Uri.file()` to parse it, which then runs into problem #2.

Long-term, there may be some additional capabilities that would be cool to explore, as Live Share adds some extensibility points (e.g. allowing opting-in to syncing checkpoints, auto-creating checkpoints when editing a file within a Live Share session, etc.). This is an awesome extension, and so I'm keen to see it support Live Share collaboration 👍 

// CC @micnil 