### PR TITLE
Feature: An option to create a checkpoint when saving the document

### DIFF
--- a/package.json
+++ b/package.json
@@ -267,6 +267,11 @@
                     "default": "en-GB",
                     "description": "Specifies the date-time locale used for the default checkpoint names. Available options: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString"
                 },
+                "checkpoints.addCheckpointOnSave": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Determines wheter to create a new checkpoint when the file is saved"
+                },
                 "checkpoints.askForCheckpointName": {
                     "type": "boolean",
                     "default": true,

--- a/src/CheckpointsController.ts
+++ b/src/CheckpointsController.ts
@@ -104,7 +104,7 @@ export class CheckpointsController {
 	 * the checkpoint model.
 	*/
 	private async onAddCheckpoint() {
-
+		this.activeEditor = window.activeTextEditor;
 		if (this.activeEditor.document.uri.scheme === "untitled") {
 			console.log(`Failed to add file to store. Unsaved documents are currently not supported`);
 			window.showInformationMessage("Untitled documents are currently not supported");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 'use strict';
-import { ExtensionContext } from 'vscode';
+import { ExtensionContext, commands, workspace, TextDocument, WorkspaceEdit } from 'vscode';
 import { CheckpointsModel } from './CheckpointsModel';
 import { CheckpointsTreeView } from './CheckpointsTreeView';
 import { CheckpointsController } from './CheckpointsController';
@@ -25,8 +25,21 @@ export function activate(context: ExtensionContext) {
 		checkpointsTreeView,
 		checkpointsDocumentView,
     );
+
+    workspace.onDidSaveTextDocument((document: TextDocument) => {
+        const config = workspace.getConfiguration('checkpoints');        
+		const addCheckpointOnSave: boolean = config.get('addCheckpointOnSave');
+        if (addCheckpointOnSave === true) {
+            commands.executeCommand("checkpoints.addCheckpoint").then((edit: WorkspaceEdit) => {
+                if (!edit) throw Error;
+                return workspace.applyEdit(edit);
+            }) .then(undefined, err => {
+               console.error('Failed to add checkpoint on document save', err);
+            });
+        }
+	});
     
-	checkpointsController.initialize();
+    checkpointsController.initialize();
 }
 
 // this method is called when your extension is deactivated


### PR DESCRIPTION
A feature to add an option to create a checkpoint on each time you save the document. I think that each document save is a really good time to add checkpoint. It's that time when you are ready to run whatever you just wrote 